### PR TITLE
Defensive programming has been implemented in the command for series and movies.

### DIFF
--- a/actions/subtitles_command.py
+++ b/actions/subtitles_command.py
@@ -10,6 +10,7 @@ from providers.OMDbAPI import search_movie_by_name
 from providers.YIFY import search_subtitles_by_imdb
 from resources.properties import LANGUAGE_FLAG_CODES, SUBTITLES_LISTED_BY_DEFAULT
 from src.logger import logger
+from src.utils import join_remaining_parts, message_exceeds_size
 from strings.subtitles_command import INCORRECT_SUBTITLES_FORMAT, LANGUAGE_NOT_AVAILABLE, NO_IMDB_ID_FOUND, NO_SUBTITLES_FOUND
 from strings.subtitles_command import SEARCH_SERIES_SUBTITLE_COMMAND
 
@@ -178,7 +179,6 @@ def generate_template_information(movie_subtitles: List[ByIMDb]) -> List[Display
 
 
 def process_rating_value(rating_number: int) -> str:
-
     if rating_number < 0:
         rating_text = f"{rating_number} \u274C"
     elif rating_number == 0:
@@ -196,9 +196,8 @@ def generate_template(template_information: List[DisplaySubtitleInformation], co
     remaining_messages = []
 
     for index, movie_subtitle in enumerate(template_information, start=1):
-        temp_text = ''
         if index <= display_limit:
-            temp_text = temp_text + f"<strong><u>Option {index}</u></strong>\n"
+            temp_text = f"<strong><u>Option {index}</u></strong>\n"
             temp_text = temp_text + f"\n"
             temp_text = temp_text + f"<strong>Rating:</strong> {movie_subtitle.rating}\n"
             temp_text = temp_text + f"<strong>Language:</strong> {movie_subtitle.language}\n"
@@ -221,26 +220,5 @@ def generate_template(template_information: List[DisplaySubtitleInformation], co
         result = SendInformation(cover_url, first_message, reduce_remaining_parts)
     else:
         result = SendInformation(cover_url, first_message)
-
-    return result
-
-
-def message_exceeds_size(text: str) -> bool:
-    # The maximum number of characters in a message is 4096
-    return len(text) > 4096
-
-
-def join_remaining_parts(remaining_parts: List[str]) -> List[str]:
-    result = []
-
-    temp_text = ''
-    for remaining_part in remaining_parts:
-        exceeds_size = message_exceeds_size(temp_text)
-        if not exceeds_size:
-            temp_text = temp_text + remaining_part
-        else:
-            result.append(temp_text)
-            temp_text = ''
-            temp_text = temp_text + remaining_part
 
     return result

--- a/classes/MoviesCommand.py
+++ b/classes/MoviesCommand.py
@@ -36,12 +36,13 @@ class DisplayMovieInformation:
 
 
 class SendInformation:
-    def __init__(self, photo_url: str = '', message: str = ''):
+    def __init__(self, photo_url: str = '', message: str = '', remaining_messages: List[str] = None):
         self.photo_url = photo_url
         self.message = message
+        self.remaining_messages = remaining_messages
 
     def __str__(self):
-        return f"Photo URL: {self.photo_url}\nMessage: {self.message}\n"
+        return f"Photo URL: {self.photo_url}\nMessage: {self.message}\nRemaining messages: {self.remaining_messages}\n"
 
 
 class Options:

--- a/classes/SeriesCommand.py
+++ b/classes/SeriesCommand.py
@@ -40,12 +40,13 @@ class TemplateInformation:
 
 
 class SendInformation:
-    def __init__(self, photo_url: str = '', message: str = ''):
+    def __init__(self, photo_url: str = '', message: str = '', remaining_messages: List[str] = None):
         self.photo_url = photo_url
         self.message = message
+        self.remaining_messages = remaining_messages
 
     def __str__(self):
-        return f"Photo URL: {self.photo_url}\nMessage: {self.message}\n"
+        return f"Photo URL: {self.photo_url}\nMessage: {self.message}\nRemaining messages: {self.remaining_messages}\n"
 
 
 class Options:

--- a/src/command_handlers.py
+++ b/src/command_handlers.py
@@ -62,7 +62,13 @@ def series_command(update: Update, context: CallbackContext) -> None:
 
     photo_url = available_options.photo_url
     response_message = available_options.message
-    send_message(update, identifier, photo_url, response_message)
+    remaining_messages = available_options.remaining_messages
+
+    if not remaining_messages:
+        send_message(update, identifier, photo_url, response_message)
+    else:
+        send_message(update, identifier, photo_url, response_message)
+        send_remaining_messages(update, identifier, remaining_messages)
 
 
 def movies_command(update: Update, context: CallbackContext) -> None:
@@ -76,7 +82,13 @@ def movies_command(update: Update, context: CallbackContext) -> None:
 
     photo_url = available_options.photo_url
     response_message = available_options.message
-    send_message(update, identifier, photo_url, response_message)
+    remaining_messages = available_options.remaining_messages
+
+    if not remaining_messages:
+        send_message(update, identifier, photo_url, response_message)
+    else:
+        send_message(update, identifier, photo_url, response_message)
+        send_remaining_messages(update, identifier, remaining_messages)
 
 
 def subtitles_command(update: Update, context: CallbackContext) -> None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Any
+from typing import Any, List
 
 import requests
 
@@ -32,3 +32,28 @@ def handle_request(api_url: str, headers: Any, parameters: Any) -> Any:
         logger.warning(f"Error: {request_exception}")
 
     return None
+
+
+# The maximum number of characters in a message is 4096
+def message_exceeds_size(text: str) -> bool:
+    return len(text) > 4096
+
+
+def join_remaining_parts(remaining_parts: List[str]) -> List[str]:
+    result = []
+
+    number_remaining_parts = len(remaining_parts)
+    temp_text = ''
+    for index, remaining_part in enumerate(remaining_parts, start=1):
+        temp_text = temp_text + remaining_part
+        exceeds_size = message_exceeds_size(temp_text)
+        if not exceeds_size:
+            if index != number_remaining_parts:
+                continue
+            else:
+                result.append(temp_text)
+        else:
+            result.append(temp_text)
+            temp_text = '' + remaining_part
+
+    return result


### PR DESCRIPTION
Until now, only the length of the message to be sent was controlled in the subtitle command. In case there were too many options in the series or movies when displaying the results, this could cause an internal error and no response would be sent. The message is now split into several messages to avoid this problem and the bot has no errors in that scenario.