### PR TITLE
Changed the logic in the command to search for series

### DIFF
--- a/actions/series_command.py
+++ b/actions/series_command.py
@@ -166,13 +166,10 @@ def filter_available_torrents(options: Options, available_results: ByIMDb) -> Li
 def get_torrents_matches_user_options(options: Options, torrents: List[TorrentAvailable]) -> List[TorrentAvailable]:
     filtered_torrents = []
 
-    full_season_torrents = filter_full_season_torrents(options, torrents)
-    if full_season_torrents:
-        return full_season_torrents
-    else:
-        for torrent in torrents:
-            if options.season == torrent.season and options.episode == torrent.episode and torrent.title.find(options.quality) != -1:
-                filtered_torrents.append(torrent)
+    filtered_torrents = filter_full_season_torrents(options, torrents)
+    for torrent in torrents:
+        if options.season == torrent.season and options.episode == torrent.episode and torrent.title.find(options.quality) != -1:
+            filtered_torrents.append(torrent)
 
     return filtered_torrents
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.14.5
 chardet==4.0.0
 cryptography==3.4.7
 cssselect==1.1.0
-decorator==5.0.6
+decorator==5.0.7
 idna==2.10 # requests depends on this version
 lxml==4.6.3
 pycparser==2.20


### PR DESCRIPTION
Changed the logic in the command to search for series when prioritising the results.

Now, the first results will always be full season packs. The following results will correspond to the requested episode. This is done to avoid showing only packs that may not contain subtitles, so if you want to get the individual episode with subtitles it is now possible.

Updated decorator dependency from 5.0.6 to 5.0.7.